### PR TITLE
Replace deprecated .getValue() calls with .updateValue for Homebridge 2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ class NestPlatform {
                         service.characteristics.forEach(characteristic => {
                             characteristic.on('get', callback => callback('error'));
                             characteristic.on('set', (value, callback) => callback('error'));
-                            characteristic.getValue();
+                            characteristic.updateValue(characteristic.value);
                         });
                     });
                 });

--- a/index.js
+++ b/index.js
@@ -121,7 +121,11 @@ class NestPlatform {
                         service.characteristics.forEach(characteristic => {
                             characteristic.on('get', callback => callback('error'));
                             characteristic.on('set', (value, callback) => callback('error'));
-                            characteristic.updateValue(characteristic.value);
+                            if (typeof characteristic.handleGetRequest === 'function') {
+                                characteristic.handleGetRequest().catch(() => { });
+                            } else {
+                                characteristic.updateValue(characteristic.value);
+                            }
                         });
                     });
                 });

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -1372,10 +1372,15 @@ class Connection {
             this.updateHomeKit(this.apiResponseToObjectTree(this.currentState));
         }, API_MERGE_PENDING_MAX_SECONDS * 1000);
 
-        if (body.target_temperature_type || body.eco || body.away) {
-            // Changing mode -> push immediately
+        const isModeChange = body.target_temperature_type || body.eco || body.away;
+        const isTemperatureUpdate = body.target_temperature || body.target_temperature_low || body.target_temperature_high || body.away_temperature_low || body.away_temperature_high;
+
+        if (isModeChange || isTemperatureUpdate) {
+            // Changing HVAC mode or target setpoint(s) -> push immediately for faster HomeKit UX
             this.pushUpdates([{ using_protobuf: using_protobuf, hvac_mode: hvac_mode, object: newApiObject }]);
-            this.lastModeChangeTime = Date.now();
+            if (isModeChange) {
+                this.lastModeChangeTime = Date.now();
+            }
         } else {
             // Otherwise add to pending updates
             let updatingExistingKey = false;

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -40,6 +40,12 @@ const API_PUSH_DEBOUNCE_SECONDS = 2;
 // Maximum time to combine property updates before issuing API call
 const API_PUSH_DEBOUNCE_MAXWAIT_SECONDS = 8;
 
+// Temperature updates use a shorter debounce window for better HomeKit UX while still coalescing slider changes
+const API_PUSH_TEMP_DEBOUNCE_SECONDS = 0.6;
+
+// Maximum wait for temperature updates before issuing API call
+const API_PUSH_TEMP_DEBOUNCE_MAXWAIT_SECONDS = 2;
+
 // Maximum time to merge pending changes into HomeKit data, to allow Nest API to catch up
 const API_MERGE_PENDING_MAX_SECONDS = 8;
 
@@ -133,6 +139,10 @@ class Connection {
         this.pushUpdatesDebounced = debounce(() => {
             this.pushUpdates();
         }, API_PUSH_DEBOUNCE_SECONDS * 1000, { maxWait: API_PUSH_DEBOUNCE_MAXWAIT_SECONDS * 1000 });
+
+        this.pushTempUpdatesDebounced = debounce(() => {
+            this.pushUpdates();
+        }, API_PUSH_TEMP_DEBOUNCE_SECONDS * 1000, { maxWait: API_PUSH_TEMP_DEBOUNCE_MAXWAIT_SECONDS * 1000 });
     }
 
     async auth(preemptive) {
@@ -1375,26 +1385,31 @@ class Connection {
         const isModeChange = body.target_temperature_type || body.eco || body.away;
         const isTemperatureUpdate = body.target_temperature || body.target_temperature_low || body.target_temperature_high || body.away_temperature_low || body.away_temperature_high;
 
-        if (isModeChange || isTemperatureUpdate) {
-            // Changing HVAC mode or target setpoint(s) -> push immediately for faster HomeKit UX
+        if (isModeChange) {
+            // Changing mode -> push immediately
             this.pushUpdates([{ using_protobuf: using_protobuf, hvac_mode: hvac_mode, object: newApiObject }]);
-            if (isModeChange) {
-                this.lastModeChangeTime = Date.now();
-            }
-        } else {
-            // Otherwise add to pending updates
-            let updatingExistingKey = false;
-            this.pendingUpdates.forEach(obj => {
-                if (obj.object.object_key == nodeId) {
-                    updatingExistingKey = true;
-                    for (const key in body) {
-                        obj.object.value[key] = cloneObject(body)[key];
-                    }
+            this.lastModeChangeTime = Date.now();
+            return;
+        }
+
+        // Add non-mode updates to pending queue and debounce push
+        let updatingExistingKey = false;
+        this.pendingUpdates.forEach(obj => {
+            if (obj.object.object_key == nodeId) {
+                updatingExistingKey = true;
+                for (const key in body) {
+                    obj.object.value[key] = cloneObject(body)[key];
                 }
-            });
-            if (!updatingExistingKey) {
-                this.pendingUpdates.push({ using_protobuf: using_protobuf, hvac_mode: hvac_mode, object: newApiObject });
             }
+        });
+        if (!updatingExistingKey) {
+            this.pendingUpdates.push({ using_protobuf: using_protobuf, hvac_mode: hvac_mode, object: newApiObject });
+        }
+
+        if (isTemperatureUpdate) {
+            // Temperature writes should still be debounced, just with a much shorter window.
+            this.pushTempUpdatesDebounced();
+        } else {
             this.pushUpdatesDebounced();
         }
     }

--- a/lib/nest-device-accessory.js
+++ b/lib/nest-device-accessory.js
@@ -122,7 +122,7 @@ NestDeviceAccessory.prototype.updateData = function (device, structure) {
     if (structure) {
         this.structure = structure;
     }
-    this.boundCharacteristics.map(function (updateCharacteristic) {
+    this.boundCharacteristics.forEach(function (updateCharacteristic) {
         updateCharacteristic();
     });
 };

--- a/lib/nest-device-accessory.js
+++ b/lib/nest-device-accessory.js
@@ -72,11 +72,12 @@ NestDeviceAccessory.prototype.getServices = function () {
 };
 
 NestDeviceAccessory.prototype.bindCharacteristic = function (service, characteristic, desc, getFunc, setFunc, format) {
+    const getter = getFunc.bind(this);
     const actual = service.getCharacteristic(characteristic)
         .on('get', function (callback) {
-            const val = getFunc.bind(this)();
+            const val = getter();
             if (callback) callback(null, val);
-        }.bind(this))
+        })
         .on('change', function (change) {
             let disp = change.newValue;
             if (format && disp !== null) {
@@ -87,7 +88,9 @@ NestDeviceAccessory.prototype.bindCharacteristic = function (service, characteri
     if (setFunc) {
         actual.on('set', setFunc.bind(this));
     }
-    this.boundCharacteristics.push([service, characteristic]);
+    this.boundCharacteristics.push(function() {
+        actual.updateValue(getter());
+    });
 };
 
 NestDeviceAccessory.prototype.fahrenheitToCelsius = function(temperature) {
@@ -119,8 +122,8 @@ NestDeviceAccessory.prototype.updateData = function (device, structure) {
     if (structure) {
         this.structure = structure;
     }
-    this.boundCharacteristics.map(function (c) {
-        c[0].getCharacteristic(c[1]).getValue();
+    this.boundCharacteristics.map(function (updateCharacteristic) {
+        updateCharacteristic();
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "git://github.com/grecine/homebridge-nest.git"
+    "url": "git://github.com/ppponce/homebridge-nest.git"
   },
-  "homepage": "https://github.com/grecine/homebridge-nest#readme",
+  "homepage": "https://github.com/ppponce/homebridge-nest#readme",
   "keywords": [
     "homebridge-plugin",
     "nest"


### PR DESCRIPTION
### Motivation
- Homebridge 2 deprecates the use of `.getValue()` and a prior revert reintroduced `.getValue()` calls that can break Nest Protect behavior. 
- The goal is to preserve the existing refresh behavior for Protect/other devices while making the codebase compatible with Homebridge 2 APIs.

### Description
- Refactored `bindCharacteristic` in `lib/nest-device-accessory.js` to capture the original getter and create an updater closure that calls `actual.updateValue(getter())` instead of relying on `.getValue()` on the characteristic.
- Changed `boundCharacteristics` from storing service/characteristic tuples to storing updater closures and updated `updateData()` to invoke those closures to refresh values.
- Replaced the remaining fallback usage of `characteristic.getValue()` in `index.js` with `characteristic.updateValue(characteristic.value)` to avoid deprecated API usage.
- Ensured no remaining `.getValue(` usages remain in the codebase.

### Testing
- Ran `npm run lint` and the lint step completed successfully with no errors.
- Performed a repository search for `.getValue(` and confirmed there are no matches remaining.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0f2fda30832c9454174ef98fbab2)