### PR TITLE
Opt-in Protobuf support for Nest Protect and mapping of legacy Protect info

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Set `"options"` in `config.json` to an array of strings chosen from the followin
 * `"HomeAway.AsOccupancySensorAndSwitch"` - create Home/Away indicator as an *OccupancySensor* and a *Switch*
 * `"Protect.Disable"` - exclude Nest Protects from HomeKit
 * `"Protect.MotionSensor.Disable"` - disable *MotionDetector* accessory for Nest Protects
+* `"Protect.Protobuf.Enable"` - opt in to mounting Nest Protect devices discovered over protobuf (experimental)
 * `"Lock.Disable"` - exclude Nest x Yale Locks from HomeKit
 * `"Nest.FieldTest.Enable"` - set this option if you're using a Nest Field Test account (experimental)
 

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -81,6 +81,7 @@ const CLIENT_ID = '733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleuser
 
 // Client ID of the Test Flight Beta Nest iOS application
 const CLIENT_ID_FT = '384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com';
+const PROTECT_PROTOBUF_DEVICE_TYPES = ['nest.resource.NestProtect2LinePoweredResource', 'nest.resource.NestProtect2BatteryPoweredResource'];
 
 class Connection {
     constructor(config, log, verbose, fieldTestMode) {
@@ -875,6 +876,14 @@ class Connection {
                                     // Nest x Yale Lock
                                     this.verbose('----> mounting as Nest x Yale Lock');
                                     initDevice('yale', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                } else if (PROTECT_PROTOBUF_DEVICE_TYPES.includes(deviceType)) {
+                                    // Nest Protect 2nd Gen (wired/battery)
+                                    if (this.config.options && this.config.options.includes('Protect.Protobuf.Enable')) {
+                                        this.verbose('----> mounting as Nest Protect (protobuf)');
+                                        initDevice('topaz', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                    } else {
+                                        this.verbose('----> detected Nest Protect on protobuf (keeping REST/topaz as primary path)');
+                                    }
                                 } else {
                                     this.verbose('----> ignoring as currently unsupported type');
                                     // Log ALL unsupported device types
@@ -921,6 +930,28 @@ class Connection {
                             body[deviceKey][id][deviceKey == 'topaz' ? 'model' : 'model_name'] = deviceIdentity.data.property.value.modelName && deviceIdentity.data.property.value.modelName.value;
                             body[deviceKey][id].serial_number = deviceIdentity.data.property.value.serialNumber;
                             body[deviceKey][id].current_version = deviceIdentity.data.property.value.fwVersion;
+                        }
+                    });
+
+                    translateProperty(object, 'legacy_protect_device_info', null, (legacyProtectDeviceInfo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let info = legacyProtectDeviceInfo.data.property.value || {};
+                            let thisDevice = body.topaz[id];
+
+                            // Occupancy signal (mapped to Protect auto_away in accessory layer)
+                            if (info.autoAway && info.autoAway.value !== undefined) {
+                                thisDevice.auto_away = !!info.autoAway.value;
+                            }
+
+                            // Manual test signal
+                            if (info.manualTestInProgress && info.manualTestInProgress.value !== undefined) {
+                                thisDevice.is_manual_test_active = !!info.manualTestInProgress.value;
+                            }
+
+                            // Preserve wired/battery distinction when exposed by protobuf trait
+                            if (info.linePowerPresent && info.linePowerPresent.value !== undefined) {
+                                thisDevice.line_power_present = !!info.linePowerPresent.value;
+                            }
                         }
                     });
 


### PR DESCRIPTION
### Motivation

- Add optional support for Nest Protect devices that appear on the protobuf API so users can opt in to mounting Protects discovered over protobuf.
- Preserve and expose protobuf-specific Protect signals (auto-away, manual test, and line/battery power) into the existing `topaz` device model for HomeKit use.

### Description

- Added a new README option `Protect.Protobuf.Enable` documented in `README.md` to allow opting in to protobuf-mounted Protect devices.
- Introduced `PROTECT_PROTOBUF_DEVICE_TYPES` constant and added detection logic to mount protobuf-discovered Protects as `topaz` when `Protect.Protobuf.Enable` is present in `config.options`.
- Added a `legacy_protect_device_info` property translator to map protobuf fields into the `body.topaz[deviceId]` object, populating `auto_away`, `is_manual_test_active`, and `line_power_present` when available.
- Added logging when protobuf Protects are detected but not enabled so they are retained as REST/topaz primary path by default.

### Testing

- Ran the repository lint task via `npm run lint` and it completed successfully.
- Ran the automated test suite via `npm test` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf61609a0832c87846682e52ca3c9)