### PR TITLE
Add experimental protobuf-based Nest Protect support and map Protect traits to legacy topaz

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Set `"options"` in `config.json` to an array of strings chosen from the followin
 * `"HomeAway.AsOccupancySensorAndSwitch"` - create Home/Away indicator as an *OccupancySensor* and a *Switch*
 * `"Protect.Disable"` - exclude Nest Protects from HomeKit
 * `"Protect.MotionSensor.Disable"` - disable *MotionDetector* accessory for Nest Protects
+* `"Protect.Protobuf.Enable"` - opt in to mounting Nest Protect devices discovered over protobuf (experimental)
 * `"Lock.Disable"` - exclude Nest x Yale Locks from HomeKit
 * `"Nest.FieldTest.Enable"` - set this option if you're using a Nest Field Test account (experimental)
 

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -81,6 +81,7 @@ const CLIENT_ID = '733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleuser
 
 // Client ID of the Test Flight Beta Nest iOS application
 const CLIENT_ID_FT = '384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com';
+const PROTECT_PROTOBUF_DEVICE_TYPES = ['nest.resource.NestProtect2LinePoweredResource', 'nest.resource.NestProtect2BatteryPoweredResource'];
 
 class Connection {
     constructor(config, log, verbose, fieldTestMode) {
@@ -711,6 +712,61 @@ class Connection {
             return id.split('_')[1];
         }
 
+        function findEnumValue(obj, matchers) {
+            if (!obj) {
+                return null;
+            }
+            if (typeof(obj) == 'string') {
+                return matchers.some(matcher => obj.includes(matcher)) ? obj : null;
+            }
+            if (Array.isArray(obj)) {
+                for (const el of obj) {
+                    const found = findEnumValue(el, matchers);
+                    if (found) {
+                        return found;
+                    }
+                }
+                return null;
+            }
+            if (typeof(obj) == 'object') {
+                for (const key in obj) {
+                    const found = findEnumValue(obj[key], matchers);
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
+            return null;
+        }
+
+        function toBinaryStatusFromEnum(enumValue, healthyMatchers) {
+            if (!enumValue || typeof(enumValue) != 'string') {
+                return null;
+            }
+            return healthyMatchers.some(matcher => enumValue.includes(matcher)) ? 0 : 1;
+        }
+
+        function summarizeProtobufKeys(keyList) {
+            let important = keyList.filter(el => ['legacy_protect_device_info', 'self_test', 'audio_test', 'safety_summary', 'safety_alarm_smoke', 'safety_alarm_co', 'smoke', 'carbon_monoxide', 'battery', 'battery_power_source', 'liveness', 'peer_devices'].includes(el[0]));
+            let sample = keyList.slice(0, 8).map(el => el[0] + '@' + el[1]);
+            return {
+                count: keyList.length,
+                important_count: important.length,
+                important: important.map(el => el[0] + '@' + el[1]),
+                sample: sample
+            };
+        }
+
+        function setProtectManualTestState(thisDevice, active) {
+            if (active === null || active === undefined) {
+                return;
+            }
+            thisDevice.is_manual_test_active = !!active;
+            if (thisDevice.is_manual_test_active) {
+                thisDevice.manual_test_state_source = 'protobuf';
+            }
+        }
+
         const translateProperty = (object, propName, constructor, enumerator) => {
             let propObjects = getProtoObject(object, propName);
             if (propObjects) {
@@ -775,7 +831,11 @@ class Connection {
                     transformTraits(object, this.proto);
 
                     let keyList = getProtoKeys(object);
-                    this.verbose('Protobuf updated properties:', keyList.map(el => el[0] + '@' + el[1] + ' (' + el[2] + ')').join(', '));
+                    let keySummary = summarizeProtobufKeys(keyList);
+                    this.verbose('Protobuf updated properties:', keySummary.count, 'key(s), important', keySummary.important_count, 'sample', keySummary.sample.join(', '));
+                    if (keySummary.important.length > 0) {
+                        this.verbose('Protobuf important keys:', keySummary.important.join(', '));
+                    }
 
                     translateProperty(object, 'user_info', null, userInfo => {
                         this.verbose('Legacy user mapping', userInfo.object.id, '->', userInfo.data.property.value.legacyId);
@@ -828,6 +888,9 @@ class Connection {
                             body.track = {};
                         }
                         body.track[id] = { online: liveness.data.property.value.status == 'LIVENESS_DEVICE_STATUS_ONLINE' };
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            body.topaz[id].component_wifi_test_passed = body.track[id].online;
+                        }
                         // }
                     });
 
@@ -875,6 +938,14 @@ class Connection {
                                     // Nest x Yale Lock
                                     this.verbose('----> mounting as Nest x Yale Lock');
                                     initDevice('yale', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                } else if (PROTECT_PROTOBUF_DEVICE_TYPES.includes(deviceType)) {
+                                    // Nest Protect 2nd Gen (wired/battery)
+                                    if (this.config.options && this.config.options.includes('Protect.Protobuf.Enable')) {
+                                        this.verbose('----> mounting as Nest Protect (protobuf)');
+                                        initDevice('topaz', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                    } else {
+                                        this.verbose('----> detected Nest Protect on protobuf (keeping REST/topaz as primary path)');
+                                    }
                                 } else {
                                     this.verbose('----> ignoring as currently unsupported type');
                                     // Log ALL unsupported device types
@@ -921,6 +992,104 @@ class Connection {
                             body[deviceKey][id][deviceKey == 'topaz' ? 'model' : 'model_name'] = deviceIdentity.data.property.value.modelName && deviceIdentity.data.property.value.modelName.value;
                             body[deviceKey][id].serial_number = deviceIdentity.data.property.value.serialNumber;
                             body[deviceKey][id].current_version = deviceIdentity.data.property.value.fwVersion;
+                        }
+                    });
+
+                    translateProperty(object, 'legacy_protect_device_info', null, (legacyProtectDeviceInfo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let info = legacyProtectDeviceInfo.data.property.value || {};
+                            let thisDevice = body.topaz[id];
+
+                            // Occupancy signal (mapped to Protect auto_away in accessory layer)
+                            if (info.autoAway && info.autoAway.value !== undefined) {
+                                thisDevice.auto_away = !!info.autoAway.value;
+                            }
+
+                            // Manual test signal
+                            if (info.manualTestInProgress && info.manualTestInProgress.value !== undefined) {
+                                setProtectManualTestState(thisDevice, info.manualTestInProgress.value);
+                            }
+
+                            // Preserve wired/battery distinction when exposed by protobuf trait
+                            if (info.linePowerPresent && info.linePowerPresent.value !== undefined) {
+                                thisDevice.line_power_present = !!info.linePowerPresent.value;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'smoke', null, (smokeStatus, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(smokeStatus.data.property.value, ['SMOKE_STATUS', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].smoke_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'carbon_monoxide', null, (carbonMonoxideStatus, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(carbonMonoxideStatus.data.property.value, ['CARBON_MONOXIDE', 'CO_STATUS', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].co_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_alarm_smoke', null, (safetyAlarmSmoke, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(safetyAlarmSmoke.data.property.value, ['SAFETY_ALARM_STATE', 'SMOKE_STATUS', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].smoke_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_alarm_co', null, (safetyAlarmCo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(safetyAlarmCo.data.property.value, ['SAFETY_ALARM_STATE', 'CO_STATUS', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].co_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'self_test', null, (selfTest, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(selfTest.data.property.value, ['SELF_TEST', 'STATUS', 'STATE']);
+                            if (enumValue) {
+                                let active = !['IDLE', 'NONE', 'UNSPECIFIED', 'OK', 'COMPLETE', 'COMPLETED'].some(matcher => enumValue.includes(matcher));
+                                setProtectManualTestState(body.topaz[id], active);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'audio_test', null, (audioTest, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(audioTest.data.property.value, ['AUDIO_TEST', 'STATUS', 'STATE']);
+                            if (enumValue) {
+                                let active = !['IDLE', 'NONE', 'UNSPECIFIED', 'OK', 'PASS', 'COMPLETE', 'COMPLETED'].some(matcher => enumValue.includes(matcher));
+                                setProtectManualTestState(body.topaz[id], active);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_summary', null, (safetySummary, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let smokeValue = findEnumValue(safetySummary.data.property.value, ['SMOKE', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let smokeStatus = toBinaryStatusFromEnum(smokeValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (smokeStatus !== null) {
+                                body.topaz[id].smoke_status = smokeStatus;
+                            }
+
+                            let coValue = findEnumValue(safetySummary.data.property.value, ['CO_', 'CARBON_MONOXIDE', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let coStatus = toBinaryStatusFromEnum(coValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (coStatus !== null) {
+                                body.topaz[id].co_status = coStatus;
+                            }
                         }
                     });
 
@@ -1062,6 +1231,13 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body[deviceKey][id].battery_status = batteryStatus.data.property.value.replacementIndicator;
                             body[deviceKey][id].battery_voltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                            if (deviceKey == 'topaz') {
+                                let replacement = batteryStatus.data.property.value.replacementIndicator;
+                                let state = toBinaryStatusFromEnum(replacement, ['NOT_AT_ALL', 'NO', 'OK', 'NORMAL']);
+                                if (state !== null) {
+                                    body.topaz[id].battery_health_state = state;
+                                }
+                            }
                         }
                     });
 
@@ -1071,6 +1247,13 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body[deviceKey][id].battery_status = batteryStatus.data.property.value.replacementIndicator;
                             body[deviceKey][id].battery_voltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                            if (deviceKey == 'topaz') {
+                                let replacement = batteryStatus.data.property.value.replacementIndicator;
+                                let state = toBinaryStatusFromEnum(replacement, ['NOT_AT_ALL', 'NO', 'OK', 'NORMAL']);
+                                if (state !== null) {
+                                    body.topaz[id].battery_health_state = state;
+                                }
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
### Motivation

- Enable discovery and mounting of Nest Protect devices surfaced by the protobuf API and map their protobuf traits into the existing legacy `topaz`/Protect data model. 
- Preserve parity with REST/topaz data by translating protobuf enums and properties (smoke/CO/self-test/battery/line power/manual test) into legacy fields so existing accessory logic can consume them. 
- Make protobuf Protect mounting opt-in to avoid changing default behavior by adding a configuration option. 

### Description

- Added a README entry documenting the new opt-in option `Protect.Protobuf.Enable` to allow mounting Nest Protect devices discovered over protobuf. 
- Introduced `PROTECT_PROTOBUF_DEVICE_TYPES` and updated the protobuf device enumeration logic to optionally `initDevice('topaz', ...)` when the new option is set, otherwise keep REST/topaz as primary. 
- Extended `protobufToNestLegacy` with helper utilities `findEnumValue`, `toBinaryStatusFromEnum`, `summarizeProtobufKeys`, and `setProtectManualTestState`, improved verbose logging of protobuf key summaries, and added multiple `translateProperty` handlers to map protobuf traits into legacy fields (including `legacy_protect_device_info`, `smoke`, `carbon_monoxide`, `safety_alarm_smoke`, `safety_alarm_co`, `self_test`, `audio_test`, `safety_summary`, and battery properties). 
- Mapped battery replacement indicators to `battery_health_state`, preserved `line_power_present`, propagated manual test signals to `is_manual_test_active/manual_test_state_source`, and set `component_wifi_test_passed` from `liveness` for `topaz` devices. 

### Testing

- Ran the project test suite with `npm test` and code style checks with `npm run lint`, and both completed successfully. 
- Verified protobuf parsing and legacy mapping via local protobuf decode runs against sample message payloads to confirm smoke/CO/battery/manual-test and line-power fields are translated into the `topaz` data structure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf61609a0832c87846682e52ca3c9)