### PR TITLE
Add experimental Protobuf support for Nest Protects (Protect.Protobuf.Enable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Set `"options"` in `config.json` to an array of strings chosen from the followin
 * `"HomeAway.AsOccupancySensorAndSwitch"` - create Home/Away indicator as an *OccupancySensor* and a *Switch*
 * `"Protect.Disable"` - exclude Nest Protects from HomeKit
 * `"Protect.MotionSensor.Disable"` - disable *MotionDetector* accessory for Nest Protects
+* `"Protect.Protobuf.Enable"` - opt in to full protobuf mode for Nest Protects (experimental): mount Protects from protobuf and stop relying on REST `topaz` updates
 * `"Lock.Disable"` - exclude Nest x Yale Locks from HomeKit
 * `"Nest.FieldTest.Enable"` - set this option if you're using a Nest Field Test account (experimental)
 

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -81,6 +81,7 @@ const CLIENT_ID = '733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleuser
 
 // Client ID of the Test Flight Beta Nest iOS application
 const CLIENT_ID_FT = '384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com';
+const PROTECT_PROTOBUF_DEVICE_TYPES = ['nest.resource.NestProtect2LinePoweredResource', 'nest.resource.NestProtect2BatteryPoweredResource'];
 
 class Connection {
     constructor(config, log, verbose, fieldTestMode) {
@@ -469,7 +470,12 @@ class Connection {
 
     updateData() {
         let uri =  this.objectList.objects.length ? this.transport_url + NestEndpoints.ENDPOINT_SUBSCRIBE : 'https://' + NestEndpoints.NEST_API_HOSTNAME + '/api/0.1/user/' + this.userid + '/app_launch';
-        let body = this.objectList.objects.length ? removeSubscribeObjectValues(this.objectList) : {'known_bucket_types':['buckets','structure','shared','topaz','device','rcs_settings','kryptonite','quartz','track','where'],'known_bucket_versions':[]};
+        let knownBucketTypes = ['buckets', 'structure', 'shared', 'topaz', 'device', 'rcs_settings', 'kryptonite', 'quartz', 'track', 'where'];
+        if (this.config.options && this.config.options.includes('Protect.Protobuf.Enable')) {
+            // In protobuf Protect mode, avoid relying on REST topaz bucket updates
+            knownBucketTypes = knownBucketTypes.filter(el => el != 'topaz');
+        }
+        let body = this.objectList.objects.length ? removeSubscribeObjectValues(this.objectList) : { 'known_bucket_types': knownBucketTypes, 'known_bucket_versions': [] };
 
         if (!this.token || !this.connected) {
             this.verbose('API subscribe deferred as not connected to Nest.');
@@ -711,6 +717,61 @@ class Connection {
             return id.split('_')[1];
         }
 
+        function findEnumValue(obj, matchers) {
+            if (!obj) {
+                return null;
+            }
+            if (typeof(obj) == 'string') {
+                return matchers.some(matcher => obj.includes(matcher)) ? obj : null;
+            }
+            if (Array.isArray(obj)) {
+                for (const el of obj) {
+                    const found = findEnumValue(el, matchers);
+                    if (found) {
+                        return found;
+                    }
+                }
+                return null;
+            }
+            if (typeof(obj) == 'object') {
+                for (const key in obj) {
+                    const found = findEnumValue(obj[key], matchers);
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
+            return null;
+        }
+
+        function toBinaryStatusFromEnum(enumValue, healthyMatchers) {
+            if (!enumValue || typeof(enumValue) != 'string') {
+                return null;
+            }
+            return healthyMatchers.some(matcher => enumValue.includes(matcher)) ? 0 : 1;
+        }
+
+        function summarizeProtobufKeys(keyList) {
+            let important = keyList.filter(el => ['legacy_protect_device_info', 'self_test', 'audio_test', 'safety_summary', 'safety_alarm_smoke', 'safety_alarm_co', 'smoke', 'carbon_monoxide', 'battery', 'battery_power_source', 'liveness', 'peer_devices'].includes(el[0]));
+            let sample = keyList.slice(0, 8).map(el => el[0] + '@' + el[1]);
+            return {
+                count: keyList.length,
+                important_count: important.length,
+                important: important.map(el => el[0] + '@' + el[1]),
+                sample: sample
+            };
+        }
+
+        function setProtectManualTestState(thisDevice, active) {
+            if (active === null || active === undefined) {
+                return;
+            }
+            thisDevice.is_manual_test_active = !!active;
+            if (thisDevice.is_manual_test_active) {
+                thisDevice.manual_test_state_source = 'protobuf';
+            }
+        }
+
         const translateProperty = (object, propName, constructor, enumerator) => {
             let propObjects = getProtoObject(object, propName);
             if (propObjects) {
@@ -743,6 +804,9 @@ class Connection {
             body[deviceType][deviceId].user_id = this.protobufUserId;
             if (protobufDeviceType) {
                 body[deviceType][deviceId].protobuf_device_type = protobufDeviceType;
+                if (deviceType == 'topaz') {
+                    body[deviceType][deviceId].line_power_present = (protobufDeviceType == 'nest.resource.NestProtect2LinePoweredResource');
+                }
             }
 
             if (!body.structure[structureId].swarm) {
@@ -775,7 +839,11 @@ class Connection {
                     transformTraits(object, this.proto);
 
                     let keyList = getProtoKeys(object);
-                    this.verbose('Protobuf updated properties:', keyList.map(el => el[0] + '@' + el[1] + ' (' + el[2] + ')').join(', '));
+                    let keySummary = summarizeProtobufKeys(keyList);
+                    this.verbose('Protobuf updated properties:', keySummary.count, 'key(s), important', keySummary.important_count, 'sample', keySummary.sample.join(', '));
+                    if (keySummary.important.length > 0) {
+                        this.verbose('Protobuf important keys:', keySummary.important.join(', '));
+                    }
 
                     translateProperty(object, 'user_info', null, userInfo => {
                         this.verbose('Legacy user mapping', userInfo.object.id, '->', userInfo.data.property.value.legacyId);
@@ -828,6 +896,9 @@ class Connection {
                             body.track = {};
                         }
                         body.track[id] = { online: liveness.data.property.value.status == 'LIVENESS_DEVICE_STATUS_ONLINE' };
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            body.topaz[id].component_wifi_test_passed = body.track[id].online;
+                        }
                         // }
                     });
 
@@ -875,6 +946,14 @@ class Connection {
                                     // Nest x Yale Lock
                                     this.verbose('----> mounting as Nest x Yale Lock');
                                     initDevice('yale', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                } else if (PROTECT_PROTOBUF_DEVICE_TYPES.includes(deviceType)) {
+                                    // Nest Protect 2nd Gen (wired/battery)
+                                    if (this.config.options && this.config.options.includes('Protect.Protobuf.Enable')) {
+                                        this.verbose('----> mounting as Nest Protect (protobuf)');
+                                        initDevice('topaz', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                    } else {
+                                        this.verbose('----> detected Nest Protect on protobuf (keeping REST/topaz as primary path)');
+                                    }
                                 } else {
                                     this.verbose('----> ignoring as currently unsupported type');
                                     // Log ALL unsupported device types
@@ -921,6 +1000,106 @@ class Connection {
                             body[deviceKey][id][deviceKey == 'topaz' ? 'model' : 'model_name'] = deviceIdentity.data.property.value.modelName && deviceIdentity.data.property.value.modelName.value;
                             body[deviceKey][id].serial_number = deviceIdentity.data.property.value.serialNumber;
                             body[deviceKey][id].current_version = deviceIdentity.data.property.value.fwVersion;
+                        }
+                    });
+
+                    translateProperty(object, 'legacy_protect_device_info', null, (legacyProtectDeviceInfo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let info = legacyProtectDeviceInfo.data.property.value || {};
+                            let thisDevice = body.topaz[id];
+
+                            // Occupancy signal (mapped to Protect auto_away in accessory layer)
+                            if (info.autoAway && info.autoAway.value !== undefined) {
+                                thisDevice.auto_away = !!info.autoAway.value;
+                            }
+
+                            // Manual test signal
+                            if (info.manualTestInProgress && info.manualTestInProgress.value !== undefined) {
+                                setProtectManualTestState(thisDevice, info.manualTestInProgress.value);
+                                this.verbose('[Protect Debug] manualTestInProgress', id, '->', info.manualTestInProgress.value);
+                            }
+
+                            // Preserve wired/battery distinction when exposed by protobuf trait
+                            if (info.linePowerPresent && info.linePowerPresent.value !== undefined) {
+                                thisDevice.line_power_present = !!info.linePowerPresent.value;
+                                this.verbose('[Protect Debug] linePowerPresent', id, '->', info.linePowerPresent.value, '(mapped:', thisDevice.line_power_present, ')');
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'smoke', null, (smokeStatus, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(smokeStatus.data.property.value, ['SMOKE_STATUS', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].smoke_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'carbon_monoxide', null, (carbonMonoxideStatus, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(carbonMonoxideStatus.data.property.value, ['CARBON_MONOXIDE', 'CO_STATUS', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].co_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_alarm_smoke', null, (safetyAlarmSmoke, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(safetyAlarmSmoke.data.property.value, ['SAFETY_ALARM_STATE', 'SMOKE_STATUS', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].smoke_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_alarm_co', null, (safetyAlarmCo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(safetyAlarmCo.data.property.value, ['SAFETY_ALARM_STATE', 'CO_STATUS', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].co_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'self_test', null, (selfTest, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(selfTest.data.property.value, ['SELF_TEST', 'STATUS', 'STATE']);
+                            if (enumValue) {
+                                let active = !['IDLE', 'NONE', 'UNSPECIFIED', 'OK', 'COMPLETE', 'COMPLETED'].some(matcher => enumValue.includes(matcher));
+                                setProtectManualTestState(body.topaz[id], active);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'audio_test', null, (audioTest, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(audioTest.data.property.value, ['AUDIO_TEST', 'STATUS', 'STATE']);
+                            if (enumValue) {
+                                let active = !['IDLE', 'NONE', 'UNSPECIFIED', 'OK', 'PASS', 'COMPLETE', 'COMPLETED'].some(matcher => enumValue.includes(matcher));
+                                setProtectManualTestState(body.topaz[id], active);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_summary', null, (safetySummary, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let smokeValue = findEnumValue(safetySummary.data.property.value, ['SMOKE', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let smokeStatus = toBinaryStatusFromEnum(smokeValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (smokeStatus !== null) {
+                                body.topaz[id].smoke_status = smokeStatus;
+                            }
+
+                            let coValue = findEnumValue(safetySummary.data.property.value, ['CO_', 'CARBON_MONOXIDE', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let coStatus = toBinaryStatusFromEnum(coValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (coStatus !== null) {
+                                body.topaz[id].co_status = coStatus;
+                            }
                         }
                     });
 
@@ -1062,6 +1241,18 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body[deviceKey][id].battery_status = batteryStatus.data.property.value.replacementIndicator;
                             body[deviceKey][id].battery_voltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                            if (deviceKey == 'topaz') {
+                                let replacement = batteryStatus.data.property.value.replacementIndicator;
+                                let assessedVoltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                                let state = (replacement && replacement.includes('UNSPECIFIED')) ? null : toBinaryStatusFromEnum(replacement, ['NOT_AT_ALL', 'NO', 'OK', 'NORMAL']);
+                                this.verbose('[Protect Debug] battery_power_source', id, 'replacementIndicator:', replacement, 'assessedVoltage:', assessedVoltage, 'line_power_present:', body.topaz[id].line_power_present);
+                                if (state !== null) {
+                                    body.topaz[id].battery_health_state = state;
+                                    this.verbose('[Protect Debug] battery_power_source mapped battery_health_state', id, '->', state);
+                                } else {
+                                    this.verbose('[Protect Debug] battery_power_source did not map battery_health_state (unknown replacementIndicator)', id);
+                                }
+                            }
                         }
                     });
 
@@ -1071,6 +1262,18 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body[deviceKey][id].battery_status = batteryStatus.data.property.value.replacementIndicator;
                             body[deviceKey][id].battery_voltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                            if (deviceKey == 'topaz') {
+                                let replacement = batteryStatus.data.property.value.replacementIndicator;
+                                let assessedVoltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                                let state = (replacement && replacement.includes('UNSPECIFIED')) ? null : toBinaryStatusFromEnum(replacement, ['NOT_AT_ALL', 'NO', 'OK', 'NORMAL']);
+                                this.verbose('[Protect Debug] battery', id, 'replacementIndicator:', replacement, 'assessedVoltage:', assessedVoltage, 'line_power_present:', body.topaz[id].line_power_present);
+                                if (state !== null) {
+                                    body.topaz[id].battery_health_state = state;
+                                    this.verbose('[Protect Debug] battery mapped battery_health_state', id, '->', state);
+                                } else {
+                                    this.verbose('[Protect Debug] battery did not map battery_health_state (unknown replacementIndicator)', id);
+                                }
+                            }
                         }
                     });
                 }
@@ -1206,7 +1409,8 @@ class Connection {
                         thisDevice.name = thisDevice.description || thisDevice.where_name || 'Nest Protect';
                         thisDevice.smoke_alarm_state = (thisDevice.smoke_status == 0) ? 'ok' : 'emergency';
                         thisDevice.co_alarm_state = (thisDevice.co_status == 0) ? 'ok' : 'emergency';
-                        thisDevice.battery_health = (thisDevice.battery_health_state == 0) ? 'ok' : 'low';
+                        // For line-powered Protects, treat unknown/unspecified battery state as normal
+                        thisDevice.battery_health = (thisDevice.battery_health_state == 0 || (thisDevice.line_power_present && thisDevice.battery_health_state === undefined)) ? 'ok' : 'low';
                         thisDevice.is_online = thisDevice.component_wifi_test_passed;
                         data.devices['smoke_co_alarms'][deviceId] = thisDevice;
                     } else if (deviceType == 'yale') {


### PR DESCRIPTION
### Motivation

- Add optional experimental support to mount Nest Protect devices from the protobuf API instead of relying solely on REST `topaz` updates to improve reliability when Protects appear on the protobuf stream.
- Map protobuf Protect traits into the existing legacy `topaz` shape so existing accessory logic can continue to function.

### Description

- Add a new feature option `Protect.Protobuf.Enable` in `README.md` to opt into protobuf mode for Nest Protects.
- Introduce `PROTECT_PROTOBUF_DEVICE_TYPES` and conditionally exclude the `topaz` bucket from `known_bucket_types` in `updateData()` when `Protect.Protobuf.Enable` is set so the plugin will not rely on REST `topaz` updates.
- Extend `protobufToNestLegacy()` with helper functions (`findEnumValue`, `toBinaryStatusFromEnum`, `summarizeProtobufKeys`, `setProtectManualTestState`) and additional translations to populate legacy `topaz` device fields from protobuf traits including `legacy_protect_device_info`, `smoke`, `carbon_monoxide`, `safety_alarm_smoke`, `safety_alarm_co`, `self_test`, `audio_test`, `safety_summary`, and battery properties.
- Detect and mount Protect 2nd gen device types from the protobuf device list when `Protect.Protobuf.Enable` is enabled, preserve wired/battery distinction via `line_power_present`, map liveness to `component_wifi_test_passed`, and set `battery_health` logic to treat unknown/unspecified battery state as `ok` for line-powered Protects.
- Add extra verbose/debug logging and summarised protobuf key output to aid troubleshooting.

### Testing

- Ran the repository test suite with `npm test` and the tests completed successfully.
- Ran code style checks with `npm run lint` and the linter passed without errors.
- Performed automated protobuf decoding smoke tests against sample stream payloads to validate new protobuf-to-legacy mappings and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf61609a0832c87846682e52ca3c9)