### PR TITLE
Add experimental Protobuf support for Nest Protect (Protect.Protobuf.Enable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Set `"options"` in `config.json` to an array of strings chosen from the followin
 * `"HomeAway.AsOccupancySensorAndSwitch"` - create Home/Away indicator as an *OccupancySensor* and a *Switch*
 * `"Protect.Disable"` - exclude Nest Protects from HomeKit
 * `"Protect.MotionSensor.Disable"` - disable *MotionDetector* accessory for Nest Protects
+* `"Protect.Protobuf.Enable"` - opt in to full protobuf mode for Nest Protects (experimental): mount Protects from protobuf and stop relying on REST `topaz` updates. Occupancy prefers protobuf `ambient_motion`; if unavailable it falls back to protobuf `legacy_protect_device_info.autoAway`.
 * `"Lock.Disable"` - exclude Nest x Yale Locks from HomeKit
 * `"Nest.FieldTest.Enable"` - set this option if you're using a Nest Field Test account (experimental)
 

--- a/lib/nest-connection.js
+++ b/lib/nest-connection.js
@@ -81,6 +81,7 @@ const CLIENT_ID = '733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleuser
 
 // Client ID of the Test Flight Beta Nest iOS application
 const CLIENT_ID_FT = '384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com';
+const PROTECT_PROTOBUF_DEVICE_TYPES = ['nest.resource.NestProtect2LinePoweredResource', 'nest.resource.NestProtect2BatteryPoweredResource'];
 
 class Connection {
     constructor(config, log, verbose, fieldTestMode) {
@@ -469,7 +470,12 @@ class Connection {
 
     updateData() {
         let uri =  this.objectList.objects.length ? this.transport_url + NestEndpoints.ENDPOINT_SUBSCRIBE : 'https://' + NestEndpoints.NEST_API_HOSTNAME + '/api/0.1/user/' + this.userid + '/app_launch';
-        let body = this.objectList.objects.length ? removeSubscribeObjectValues(this.objectList) : {'known_bucket_types':['buckets','structure','shared','topaz','device','rcs_settings','kryptonite','quartz','track','where'],'known_bucket_versions':[]};
+        let knownBucketTypes = ['buckets', 'structure', 'shared', 'topaz', 'device', 'rcs_settings', 'kryptonite', 'quartz', 'track', 'where'];
+        if (this.config.options && this.config.options.includes('Protect.Protobuf.Enable')) {
+            // In protobuf Protect mode, avoid relying on REST topaz bucket updates.
+            knownBucketTypes = knownBucketTypes.filter(el => el != 'topaz');
+        }
+        let body = this.objectList.objects.length ? removeSubscribeObjectValues(this.objectList) : { 'known_bucket_types': knownBucketTypes, 'known_bucket_versions': [] };
 
         if (!this.token || !this.connected) {
             this.verbose('API subscribe deferred as not connected to Nest.');
@@ -711,6 +717,280 @@ class Connection {
             return id.split('_')[1];
         }
 
+        function findEnumValue(obj, matchers) {
+            if (!obj) {
+                return null;
+            }
+            if (typeof(obj) == 'string') {
+                return matchers.some(matcher => obj.includes(matcher)) ? obj : null;
+            }
+            if (Array.isArray(obj)) {
+                for (const el of obj) {
+                    const found = findEnumValue(el, matchers);
+                    if (found) {
+                        return found;
+                    }
+                }
+                return null;
+            }
+            if (typeof(obj) == 'object') {
+                for (const key in obj) {
+                    const found = findEnumValue(obj[key], matchers);
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
+            return null;
+        }
+
+        function toBinaryStatusFromEnum(enumValue, healthyMatchers) {
+            if (!enumValue || typeof(enumValue) != 'string') {
+                return null;
+            }
+            if (['UNSPECIFIED', 'UNKNOWN'].some(matcher => enumValue.includes(matcher))) {
+                return null;
+            }
+            return healthyMatchers.some(matcher => enumValue.includes(matcher)) ? 0 : 1;
+        }
+
+        function findBooleanByKeyHints(obj, hints) {
+            if (obj === null || obj === undefined) {
+                return null;
+            }
+            if (Array.isArray(obj)) {
+                for (const el of obj) {
+                    const found = findBooleanByKeyHints(el, hints);
+                    if (found !== null) {
+                        return found;
+                    }
+                }
+                return null;
+            }
+            if (typeof(obj) == 'object') {
+                for (const [key, value] of Object.entries(obj)) {
+                    const keyMatch = hints.some(hint => key.toLowerCase().includes(hint));
+                    if (keyMatch) {
+                        if (typeof(value) == 'boolean') {
+                            return value;
+                        }
+                        if (typeof(value) == 'number' && [0, 1].includes(value)) {
+                            return !!value;
+                        }
+                        let unwrappedValue = unwrapKnownProtobufPayload(value);
+                        if (typeof(unwrappedValue) == 'boolean') {
+                            return unwrappedValue;
+                        }
+                        if (typeof(unwrappedValue) == 'number' && [0, 1].includes(unwrappedValue)) {
+                            return !!unwrappedValue;
+                        }
+                        const loose = findBooleanLoose(unwrappedValue);
+                        if (loose !== null) {
+                            return loose;
+                        }
+                    }
+                    if (typeof(value) == 'object') {
+                        const found = findBooleanByKeyHints(value, hints);
+                        if (found !== null) {
+                            return found;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        function objectToBuffer(value) {
+            if (!value) {
+                return null;
+            }
+            if (Buffer.isBuffer(value)) {
+                return value;
+            }
+            if (value instanceof Uint8Array) {
+                return Buffer.from(value);
+            }
+            if (typeof(value) == 'string') {
+                try {
+                    let decoded = Buffer.from(value, 'base64');
+                    return decoded.length ? decoded : null;
+                } catch (error) {
+                    return null;
+                }
+            }
+            if (Array.isArray(value) && value.every(el => Number.isInteger(el) && el >= 0 && el <= 255)) {
+                return Buffer.from(value);
+            }
+            if (typeof(value) == 'object' && !Array.isArray(value)) {
+                let keys = Object.keys(value);
+                if (!keys.length || !keys.every(key => /^\d+$/.test(key))) {
+                    return null;
+                }
+                keys.sort((a, b) => Number(a) - Number(b));
+                return Buffer.from(keys.map(key => Number(value[key])));
+            }
+            return null;
+        }
+
+
+        function lookupTypeFromUrl(proto, typeUrl) {
+            if (!proto || !proto.root || !typeUrl) {
+                return null;
+            }
+
+            let candidates = [];
+            let split = typeUrl.split('/');
+            if (split.length > 1) {
+                candidates.push(split[split.length - 1]);
+            }
+            candidates.push(typeUrl);
+
+            candidates = candidates.map(el => (el || '').replace(/^\./, '')).filter(Boolean);
+
+            for (const candidate of candidates) {
+                try {
+                    return proto.root.lookupType(candidate);
+                } catch (error) {
+                    // keep trying
+                }
+            }
+
+            return null;
+        }
+
+        function decodeBufferWithType(proto, typeUrl, value) {
+            if (!proto || !typeUrl) {
+                return null;
+            }
+            let buffer = objectToBuffer(value);
+            if (!buffer) {
+                return null;
+            }
+
+            let candidates = [typeUrl];
+            if (typeUrl.endsWith('AmbientMotionTrait')) {
+                candidates.push(typeUrl + '.AmbientMotionEvent');
+            }
+
+            for (const candidate of candidates) {
+                let trait = lookupTrait(proto, candidate) || lookupTypeFromUrl(proto, candidate);
+                if (trait) {
+                    try {
+                        let decoded = trait.toObject(trait.decode(buffer), { enums: String, defaults: true });
+                        if (decoded !== null && decoded !== undefined) {
+                            return decoded;
+                        }
+                    } catch (error) {
+                        // try next candidate
+                    }
+                }
+            }
+            return null;
+        }
+
+        function unwrapKnownProtobufPayload(payload, proto, preferredTypeUrl) {
+            let result = payload;
+            let depth = 0;
+            while (result !== null && result !== undefined && typeof(result) == 'object' && !Array.isArray(result) && depth < 8) {
+                // google.protobuf.Any-like wrapper or generic nested value wrapper
+                if (Object.prototype.hasOwnProperty.call(result, 'type_url') && Object.prototype.hasOwnProperty.call(result, 'value')) {
+                    let inner = result.value;
+                    if (proto) {
+                        let decodedInner = decodeBufferWithType(proto, result.type_url, inner);
+                        if (decodedInner) {
+                            result = decodedInner;
+                            depth++;
+                            continue;
+                        }
+                    }
+                    result = inner;
+                    depth++;
+                    continue;
+                }
+                if (Object.prototype.hasOwnProperty.call(result, 'value') && Object.keys(result).length <= 4) {
+                    if (typeof(result.value) == 'object') {
+                        result = result.value;
+                        depth++;
+                        continue;
+                    }
+                }
+                if (preferredTypeUrl) {
+                    let decodedPreferred = decodeBufferWithType(proto, preferredTypeUrl, result);
+                    if (decodedPreferred) {
+                        result = decodedPreferred;
+                        depth++;
+                        continue;
+                    }
+                }
+                // google.protobuf.*Value wrappers
+                if (Object.prototype.hasOwnProperty.call(result, 'bool_value')) {
+                    return result.bool_value;
+                }
+                if (Object.prototype.hasOwnProperty.call(result, 'number_value')) {
+                    return result.number_value;
+                }
+                if (Object.prototype.hasOwnProperty.call(result, 'int_value')) {
+                    return result.int_value;
+                }
+                if (Object.prototype.hasOwnProperty.call(result, 'string_value')) {
+                    return result.string_value;
+                }
+                break;
+            }
+            return result;
+        }
+
+        function findBooleanLoose(obj) {
+            if (obj === null || obj === undefined) {
+                return null;
+            }
+            if (typeof(obj) == 'boolean') {
+                return obj;
+            }
+            if (typeof(obj) == 'number' && [0, 1].includes(obj)) {
+                return !!obj;
+            }
+            if (Array.isArray(obj)) {
+                for (const el of obj) {
+                    const found = findBooleanLoose(el);
+                    if (found !== null) {
+                        return found;
+                    }
+                }
+                return null;
+            }
+            if (typeof(obj) == 'object') {
+                for (const value of Object.values(obj)) {
+                    const found = findBooleanLoose(value);
+                    if (found !== null) {
+                        return found;
+                    }
+                }
+            }
+            return null;
+        }
+
+        function summarizeProtobufKeys(keyList) {
+            let important = keyList.filter(el => ['ambient_motion', 'ambient_motion_state', 'legacy_protect_device_info', 'self_test', 'audio_test', 'safety_summary', 'safety_alarm_smoke', 'safety_alarm_co', 'smoke', 'carbon_monoxide', 'battery', 'battery_power_source', 'liveness', 'peer_devices'].includes(el[0]));
+            let sample = keyList.slice(0, 8).map(el => el[0] + '@' + el[1]);
+            return {
+                count: keyList.length,
+                important_count: important.length,
+                important: important.map(el => el[0] + '@' + el[1]),
+                sample: sample
+            };
+        }
+
+        function setProtectManualTestState(thisDevice, active) {
+            if (active === null || active === undefined) {
+                return;
+            }
+            thisDevice.is_manual_test_active = !!active;
+            if (thisDevice.is_manual_test_active) {
+                thisDevice.manual_test_state_source = 'protobuf';
+            }
+        }
+
         const translateProperty = (object, propName, constructor, enumerator) => {
             let propObjects = getProtoObject(object, propName);
             if (propObjects) {
@@ -743,6 +1023,9 @@ class Connection {
             body[deviceType][deviceId].user_id = this.protobufUserId;
             if (protobufDeviceType) {
                 body[deviceType][deviceId].protobuf_device_type = protobufDeviceType;
+                if (deviceType == 'topaz') {
+                    body[deviceType][deviceId].line_power_present = (protobufDeviceType == 'nest.resource.NestProtect2LinePoweredResource');
+                }
             }
 
             if (!body.structure[structureId].swarm) {
@@ -775,7 +1058,11 @@ class Connection {
                     transformTraits(object, this.proto);
 
                     let keyList = getProtoKeys(object);
-                    this.verbose('Protobuf updated properties:', keyList.map(el => el[0] + '@' + el[1] + ' (' + el[2] + ')').join(', '));
+                    let keySummary = summarizeProtobufKeys(keyList);
+                    this.verbose('Protobuf updated properties:', keySummary.count, 'key(s), important', keySummary.important_count, 'sample', keySummary.sample.join(', '));
+                    if (keySummary.important.length > 0) {
+                        this.verbose('Protobuf important keys:', keySummary.important.join(', '));
+                    }
 
                     translateProperty(object, 'user_info', null, userInfo => {
                         this.verbose('Legacy user mapping', userInfo.object.id, '->', userInfo.data.property.value.legacyId);
@@ -828,6 +1115,9 @@ class Connection {
                             body.track = {};
                         }
                         body.track[id] = { online: liveness.data.property.value.status == 'LIVENESS_DEVICE_STATUS_ONLINE' };
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            body.topaz[id].component_wifi_test_passed = body.track[id].online;
+                        }
                         // }
                     });
 
@@ -875,6 +1165,14 @@ class Connection {
                                     // Nest x Yale Lock
                                     this.verbose('----> mounting as Nest x Yale Lock');
                                     initDevice('yale', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                } else if (PROTECT_PROTOBUF_DEVICE_TYPES.includes(deviceType)) {
+                                    // Nest Protect 2nd Gen (wired/battery)
+                                    if (this.config.options && this.config.options.includes('Protect.Protobuf.Enable')) {
+                                        this.verbose('----> mounting as Nest Protect (protobuf)');
+                                        initDevice('topaz', deviceId, structureId, el.data.fwVersion, body, deviceType);
+                                    } else {
+                                        this.verbose('----> detected Nest Protect on protobuf (keeping REST/topaz as primary path)');
+                                    }
                                 } else {
                                     this.verbose('----> ignoring as currently unsupported type');
                                     // Log ALL unsupported device types
@@ -921,6 +1219,168 @@ class Connection {
                             body[deviceKey][id][deviceKey == 'topaz' ? 'model' : 'model_name'] = deviceIdentity.data.property.value.modelName && deviceIdentity.data.property.value.modelName.value;
                             body[deviceKey][id].serial_number = deviceIdentity.data.property.value.serialNumber;
                             body[deviceKey][id].current_version = deviceIdentity.data.property.value.fwVersion;
+                        }
+                    });
+
+                    translateProperty(object, 'legacy_protect_device_info', null, (legacyProtectDeviceInfo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let info = unwrapKnownProtobufPayload(legacyProtectDeviceInfo.data && legacyProtectDeviceInfo.data.property && legacyProtectDeviceInfo.data.property.value, this.proto, legacyProtectDeviceInfo.data && legacyProtectDeviceInfo.data.property && legacyProtectDeviceInfo.data.property.type_url) ||
+                                unwrapKnownProtobufPayload(legacyProtectDeviceInfo.data && legacyProtectDeviceInfo.data.property, this.proto, legacyProtectDeviceInfo.data && legacyProtectDeviceInfo.data.property && legacyProtectDeviceInfo.data.property.type_url) || {};
+                            let thisDevice = body.topaz[id];
+
+                            // Compatibility occupancy signal from protobuf trait named "legacy_*"
+                            // (still protobuf, not REST). Keep auto_away updated for existing code paths.
+                            let autoAway = null;
+                            if (typeof(info.autoAway) == 'boolean') {
+                                autoAway = info.autoAway;
+                            } else if (info.autoAway && info.autoAway.value !== undefined) {
+                                autoAway = !!info.autoAway.value;
+                            } else if (typeof(info.auto_away) == 'boolean') {
+                                autoAway = info.auto_away;
+                            } else if (info.auto_away && info.auto_away.value !== undefined) {
+                                autoAway = !!info.auto_away.value;
+                            } else {
+                                autoAway = findBooleanByKeyHints(info, ['autoaway', 'auto_away', 'away']);
+                            }
+                            if (autoAway !== null) {
+                                thisDevice.auto_away = !!autoAway;
+                                thisDevice.protobuf_occupancy_detected = !thisDevice.auto_away;
+                                this.verbose('[Protect Debug] legacy_protect_device_info', id, 'autoAway:', thisDevice.auto_away, '=> detected:', thisDevice.protobuf_occupancy_detected);
+                            } else {
+                                this.verbose('[Protect Debug] legacy_protect_device_info', id, 'unable to parse autoAway from keys:', JSON.stringify(Object.keys(info || {})));
+                            }
+
+                            // Manual test signal
+                            if (info.manualTestInProgress && info.manualTestInProgress.value !== undefined) {
+                                setProtectManualTestState(thisDevice, info.manualTestInProgress.value);
+                                this.verbose('[Protect Debug] manualTestInProgress', id, '->', info.manualTestInProgress.value);
+                            }
+
+                            // Preserve wired/battery distinction when exposed by protobuf trait
+                            if (typeof(info.linePowerPresent) == 'boolean') {
+                                thisDevice.line_power_present = info.linePowerPresent;
+                                this.verbose('[Protect Debug] linePowerPresent', id, '->', info.linePowerPresent, '(mapped:', thisDevice.line_power_present, ')');
+                            } else if (info.linePowerPresent && info.linePowerPresent.value !== undefined) {
+                                thisDevice.line_power_present = !!info.linePowerPresent.value;
+                                this.verbose('[Protect Debug] linePowerPresent', id, '->', info.linePowerPresent.value, '(mapped:', thisDevice.line_power_present, ')');
+                            } else if (typeof(info.linePowerCapable) == 'boolean') {
+                                thisDevice.line_power_present = info.linePowerCapable;
+                                this.verbose('[Protect Debug] linePowerCapable', id, '->', info.linePowerCapable, '(mapped:', thisDevice.line_power_present, ')');
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'ambient_motion', null, (ambientMotion, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let thisDevice = body.topaz[id];
+                            let motionPayload = unwrapKnownProtobufPayload(ambientMotion.data && ambientMotion.data.property && ambientMotion.data.property.value, this.proto, ambientMotion.data && ambientMotion.data.property && ambientMotion.data.property.type_url);
+                            if (!motionPayload || (typeof(motionPayload) == 'object' && Object.keys(motionPayload).length === 0)) {
+                                motionPayload = unwrapKnownProtobufPayload(ambientMotion.data && ambientMotion.data.property, this.proto, ambientMotion.data && ambientMotion.data.property && ambientMotion.data.property.type_url);
+                            }
+
+                            let detected = findBooleanByKeyHints(motionPayload, ['occupancy', 'motion', 'presence', 'detected']);
+                            if (detected === null) {
+                                // In some variants ambient_motion itself is already a bool/wrapper without semantic key names.
+                                detected = findBooleanLoose(motionPayload);
+                            }
+
+                            if (detected === null) {
+                                // Some protobuf variants expose only an "active" boolean for ambient motion.
+                                detected = findBooleanByKeyHints(motionPayload, ['active']);
+                            }
+
+                            if (detected === null) {
+                                let enumValue = findEnumValue(motionPayload, ['MOTION', 'OCCUPANCY', 'PRESENCE', 'STATE', 'STATUS']);
+                                if (enumValue) {
+                                    detected = !['IDLE', 'INACTIVE', 'NOT_DETECTED', 'NONE', 'CLEAR', 'AWAY', 'UNSPECIFIED', 'UNKNOWN'].some(matcher => enumValue.includes(matcher));
+                                }
+                            }
+
+                            if (detected !== null) {
+                                thisDevice.protobuf_occupancy_detected = !!detected;
+                                thisDevice.auto_away = !thisDevice.protobuf_occupancy_detected;
+                                this.verbose('[Protect Debug] ambient_motion', id, 'detected:', thisDevice.protobuf_occupancy_detected, '(auto_away:', thisDevice.auto_away, ')');
+                            } else {
+                                let rawProperty = ambientMotion.data && ambientMotion.data.property;
+                                let rawValue = rawProperty && rawProperty.value;
+                                this.verbose('[Protect Debug] ambient_motion', id, 'unable to parse occupancy from payload keys:', Object.keys(motionPayload || {}), 'raw property keys:', Object.keys(rawProperty || {}), 'raw type_url:', rawProperty && rawProperty.type_url, 'raw value type:', rawValue && rawValue.constructor && rawValue.constructor.name, 'raw value length:', rawValue && rawValue.length);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'smoke', null, (smokeStatus, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(smokeStatus.data.property.value, ['SMOKE_STATUS', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].smoke_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'carbon_monoxide', null, (carbonMonoxideStatus, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(carbonMonoxideStatus.data.property.value, ['CARBON_MONOXIDE', 'CO_STATUS', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].co_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_alarm_smoke', null, (safetyAlarmSmoke, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(safetyAlarmSmoke.data.property.value, ['SAFETY_ALARM_STATE', 'SMOKE_STATUS', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].smoke_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_alarm_co', null, (safetyAlarmCo, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(safetyAlarmCo.data.property.value, ['SAFETY_ALARM_STATE', 'CO_STATUS', 'ALARM_STATE']);
+                            let status = toBinaryStatusFromEnum(enumValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (status !== null) {
+                                body.topaz[id].co_status = status;
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'self_test', null, (selfTest, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(selfTest.data.property.value, ['SELF_TEST', 'STATUS', 'STATE']);
+                            if (enumValue) {
+                                let active = !['IDLE', 'NONE', 'UNSPECIFIED', 'OK', 'COMPLETE', 'COMPLETED'].some(matcher => enumValue.includes(matcher));
+                                setProtectManualTestState(body.topaz[id], active);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'audio_test', null, (audioTest, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let enumValue = findEnumValue(audioTest.data.property.value, ['AUDIO_TEST', 'STATUS', 'STATE']);
+                            if (enumValue) {
+                                let active = !['IDLE', 'NONE', 'UNSPECIFIED', 'OK', 'PASS', 'COMPLETE', 'COMPLETED'].some(matcher => enumValue.includes(matcher));
+                                setProtectManualTestState(body.topaz[id], active);
+                            }
+                        }
+                    });
+
+                    translateProperty(object, 'safety_summary', null, (safetySummary, id) => {
+                        if (checkDeviceExists(body, id) && this.legacyDeviceMap[id] == 'topaz') {
+                            let smokeValue = findEnumValue(safetySummary.data.property.value, ['SMOKE', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let smokeStatus = toBinaryStatusFromEnum(smokeValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (smokeStatus !== null) {
+                                body.topaz[id].smoke_status = smokeStatus;
+                            }
+
+                            let coValue = findEnumValue(safetySummary.data.property.value, ['CO_', 'CARBON_MONOXIDE', 'SAFETY_ALARM_STATE', 'ALARM_STATE']);
+                            let coStatus = toBinaryStatusFromEnum(coValue, ['OK', 'CLEAR', 'NORMAL', 'NONE', 'IDLE']);
+                            if (coStatus !== null) {
+                                body.topaz[id].co_status = coStatus;
+                            }
                         }
                     });
 
@@ -1053,6 +1513,7 @@ class Connection {
                         // console.log(legacyId, JSON.stringify(structureMode, null, 2));
                         if (body.structure[legacyId]) {
                             body.structure[legacyId].protobuf_away = ['STRUCTURE_MODE_AWAY','STRUCTURE_MODE_SLEEP','STRUCTURE_MODE_VACATION'].includes(structureMode.data.property.value.structureMode);
+                            this.verbose('[Protect Debug] structure_mode', legacyId, '->', structureMode.data.property.value.structureMode, '(protobuf_away:', body.structure[legacyId].protobuf_away, ')');
                         }
                     });
 
@@ -1062,6 +1523,18 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body[deviceKey][id].battery_status = batteryStatus.data.property.value.replacementIndicator;
                             body[deviceKey][id].battery_voltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                            if (deviceKey == 'topaz') {
+                                let replacement = batteryStatus.data.property.value.replacementIndicator;
+                                let assessedVoltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                                let state = (replacement && replacement.includes('UNSPECIFIED')) ? null : toBinaryStatusFromEnum(replacement, ['NOT_AT_ALL', 'NO', 'OK', 'NORMAL']);
+                                this.verbose('[Protect Debug] battery_power_source', id, 'replacementIndicator:', replacement, 'assessedVoltage:', assessedVoltage, 'line_power_present:', body.topaz[id].line_power_present);
+                                if (state !== null) {
+                                    body.topaz[id].battery_health_state = state;
+                                    this.verbose('[Protect Debug] battery_power_source mapped battery_health_state', id, '->', state);
+                                } else {
+                                    this.verbose('[Protect Debug] battery_power_source did not map battery_health_state (unknown replacementIndicator)', id);
+                                }
+                            }
                         }
                     });
 
@@ -1071,6 +1544,18 @@ class Connection {
                         if (checkDeviceExists(body, id)) {
                             body[deviceKey][id].battery_status = batteryStatus.data.property.value.replacementIndicator;
                             body[deviceKey][id].battery_voltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                            if (deviceKey == 'topaz') {
+                                let replacement = batteryStatus.data.property.value.replacementIndicator;
+                                let assessedVoltage = batteryStatus.data.property.value.assessedVoltage && batteryStatus.data.property.value.assessedVoltage.value;
+                                let state = (replacement && replacement.includes('UNSPECIFIED')) ? null : toBinaryStatusFromEnum(replacement, ['NOT_AT_ALL', 'NO', 'OK', 'NORMAL']);
+                                this.verbose('[Protect Debug] battery', id, 'replacementIndicator:', replacement, 'assessedVoltage:', assessedVoltage, 'line_power_present:', body.topaz[id].line_power_present);
+                                if (state !== null) {
+                                    body.topaz[id].battery_health_state = state;
+                                    this.verbose('[Protect Debug] battery mapped battery_health_state', id, '->', state);
+                                } else {
+                                    this.verbose('[Protect Debug] battery did not map battery_health_state (unknown replacementIndicator)', id);
+                                }
+                            }
                         }
                     });
                 }
@@ -1204,9 +1689,10 @@ class Connection {
                         thisDevice.device_id = deviceId;
                         thisDevice.where_name = whereLookup[thisDevice.where_id];
                         thisDevice.name = thisDevice.description || thisDevice.where_name || 'Nest Protect';
-                        thisDevice.smoke_alarm_state = (thisDevice.smoke_status == 0) ? 'ok' : 'emergency';
-                        thisDevice.co_alarm_state = (thisDevice.co_status == 0) ? 'ok' : 'emergency';
-                        thisDevice.battery_health = (thisDevice.battery_health_state == 0) ? 'ok' : 'low';
+                        thisDevice.smoke_alarm_state = (thisDevice.smoke_status === 1) ? 'emergency' : 'ok';
+                        thisDevice.co_alarm_state = (thisDevice.co_status === 1) ? 'emergency' : 'ok';
+                        // For line-powered Protects, treat unknown/unspecified battery state as normal
+                        thisDevice.battery_health = (thisDevice.battery_health_state == 0 || (thisDevice.line_power_present && thisDevice.battery_health_state === undefined)) ? 'ok' : 'low';
                         thisDevice.is_online = thisDevice.component_wifi_test_passed;
                         data.devices['smoke_co_alarms'][deviceId] = thisDevice;
                     } else if (deviceType == 'yale') {
@@ -1922,14 +2408,56 @@ function createApiObject(nodeId, value) {
 }
 
 function transformTraits(object, proto) {
+    const toBuffer = value => {
+        if (!value) {
+            return null;
+        }
+        if (Buffer.isBuffer(value)) {
+            return value;
+        }
+        if (value instanceof Uint8Array) {
+            return Buffer.from(value);
+        }
+        if (typeof(value) == 'string') {
+            try {
+                let decoded = Buffer.from(value, 'base64');
+                return decoded.length ? decoded : null;
+            } catch (error) {
+                return null;
+            }
+        }
+        if (Array.isArray(value) && value.every(el => Number.isInteger(el) && el >= 0 && el <= 255)) {
+            return Buffer.from(value);
+        }
+        if (typeof(value) == 'object' && !Array.isArray(value)) {
+            let keys = Object.keys(value);
+            if (keys.length && keys.every(key => /^\d+$/.test(key))) {
+                keys.sort((a, b) => Number(a) - Number(b));
+                return Buffer.from(keys.map(key => Number(value[key])));
+            }
+        }
+        return null;
+    };
+
     object.forEach(el => {
         let type_url = el.data.property.type_url;
-        let buffer = el.data.property.value;
+        let buffer = toBuffer(el.data.property.value);
 
         let pbufTrait = lookupTrait(proto, type_url);
+        if (!pbufTrait && proto && proto.root && type_url) {
+            try {
+                pbufTrait = proto.root.lookupType(type_url.split('/')[1]);
+            } catch (error) {
+                // Do nothing
+            }
+        }
         if (pbufTrait && buffer) {
-            // console.log('Decoding buffer for trait: ' + type_url, buffer.toString('base64'));
-            el.data.property.value = pbufTrait.toObject(pbufTrait.decode(buffer), { enums: String, defaults: true });
+            try {
+                // console.log('Decoding buffer for trait: ' + type_url, buffer.toString('base64'));
+                el.data.property.value = pbufTrait.toObject(pbufTrait.decode(buffer), { enums: String, defaults: true });
+            } catch (error) {
+                // keep original value; nested decoders may still handle wrappers
+            }
         }
     });
 }
@@ -1940,6 +2468,14 @@ function lookupTrait(proto, type_url) {
         try {
             pbufTrait = pbufTrait || proto[traitKey].lookupType(type_url.split('/')[1]);
         } catch(error) {
+            // Do nothing
+        }
+    }
+
+    if (!pbufTrait && proto && proto.root && type_url) {
+        try {
+            pbufTrait = proto.root.lookupType(type_url.split('/')[1]);
+        } catch (error) {
             // Do nothing
         }
     }

--- a/lib/nest-protect-accessory.js
+++ b/lib/nest-protect-accessory.js
@@ -122,7 +122,16 @@ class NestProtectAccessory extends NestDeviceAccessory {
     // --- Motion ---
 
     getOccupancyDetected() {
-        return this.device.auto_away ? Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED : Characteristic.OccupancyDetected.OCCUPANCY_DETECTED;
+        if (typeof(this.device.protobuf_occupancy_detected) == 'boolean') {
+            return this.device.protobuf_occupancy_detected ? Characteristic.OccupancyDetected.OCCUPANCY_DETECTED : Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED;
+        }
+        // Compatibility fallback when ambient_motion has not populated yet.
+        // auto_away may still come from protobuf legacy_protect_device_info (not REST).
+        if (typeof(this.device.auto_away) == 'boolean') {
+            return this.device.auto_away ? Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED : Characteristic.OccupancyDetected.OCCUPANCY_DETECTED;
+        }
+        // Unknown state should default to not detected to avoid persistent false positives.
+        return Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED;
     }
 
     // --- OnlineStatus ---

--- a/lib/protobuf/nest/trait/product/protect.proto
+++ b/lib/protobuf/nest/trait/product/protect.proto
@@ -1,0 +1,353 @@
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "../selftest.proto";
+import "../../../weave/common.proto";
+
+package nest.trait.product.protect;
+
+message LegacyStructureSelfTestTrait {
+    bool lastMstCancelled = 1;
+    bool mstInProgress = 2;
+    google.protobuf.Timestamp lastMstStartUtcSecs = 3;
+    google.protobuf.Timestamp lastMstEndUtcSecs = 4;
+    google.protobuf.Timestamp lastMstSuccessUtcSecs = 5;
+    bool astInProgress = 6;
+    google.protobuf.Timestamp lastAstStartUtcSecs = 7;
+    google.protobuf.Timestamp lastAstEndUtcSecs = 8;
+    google.protobuf.Timestamp astRequestUtcSecs = 9;
+    google.protobuf.Timestamp astSkipUtcSecs = 10;
+    repeated uint64 astParticipants = 11;
+
+    enum SelfTestType {
+        SELF_TEST_TYPE_UNSPECIFIED = 0;
+        SELF_TEST_TYPE_AST = 1;
+        SELF_TEST_TYPE_MST = 2;
+    }
+
+    enum StartSelfTestStatus {
+        START_SELF_TEST_STATUS_UNSPECIFIED = 0;
+        START_SELF_TEST_STATUS_OK = 1;
+        START_SELF_TEST_STATUS_FAILED = 2;
+    }
+
+    enum EndSelfTestStatus {
+        END_SELF_TEST_STATUS_UNSPECIFIED = 0;
+        END_SELF_TEST_STATUS_OK = 1;
+        END_SELF_TEST_STATUS_FAILED = 2;
+    }
+
+    message StartSelfTestRequest {
+        SelfTestType type = 1;
+        nest.trait.selftest.SelfTestRunnerTrait.TestId testId = 2;
+    }
+
+    message StartSelfTestResponse {
+        StartSelfTestStatus status = 1;
+    }
+
+    message EndSelfTestRequest {
+        SelfTestType type = 1;
+        nest.trait.selftest.SelfTestRunnerTrait.TestId testId = 2;
+    }
+
+    message EndSelfTestResponse {
+        EndSelfTestStatus status = 1;
+    }
+
+    message AutomatedSelfTestSkipEvent {}
+    message AutomatedSelfTestCompleteEvent {}
+    message ManualSelfTestCompleteEvent {}
+}
+
+message SelfTestTrait {
+    google.protobuf.Timestamp lastMstStart = 1;
+    google.protobuf.Timestamp lastMstEnd = 2;
+    bool lastMstCancelled = 3;
+    google.protobuf.Timestamp lastAstStart = 4;
+    google.protobuf.Timestamp lastAstEnd = 5;
+
+    enum SelfTestType {
+        SELF_TEST_TYPE_UNSPECIFIED = 0;
+        SELF_TEST_TYPE_AST = 1;
+        SELF_TEST_TYPE_MST = 2;
+    }
+
+    enum StartSelfTestStatus {
+        START_SELF_TEST_STATUS_UNSPECIFIED = 0;
+        START_SELF_TEST_STATUS_OK = 1;
+        START_SELF_TEST_STATUS_FAILED = 2;
+    }
+
+    enum EndSelfTestStatus {
+        END_SELF_TEST_STATUS_UNSPECIFIED = 0;
+        END_SELF_TEST_STATUS_OK = 1;
+        END_SELF_TEST_STATUS_FAILED = 2;
+    }
+
+    enum MstTrigger {
+        MST_TRIGGER_UNSPECIFIED = 0;
+        MST_TRIGGER_BUTTON = 1;
+        MST_TRIGGER_REMOTE = 2;
+        MST_TRIGGER_APP = 3;
+    }
+
+    message StartSelfTestRequest {
+        SelfTestType type = 1;
+        nest.trait.selftest.SelfTestRunnerTrait.TestId testId = 2;
+    }
+
+    message StartSelfTestResponse {
+        StartSelfTestStatus status = 1;
+    }
+
+    message EndSelfTestRequest {
+        SelfTestType type = 1;
+        nest.trait.selftest.SelfTestRunnerTrait.TestId testId = 2;
+    }
+
+    message EndSelfTestResponse {
+        EndSelfTestStatus status = 1;
+    }
+
+    message MstTransitionEvent {
+        MstTrigger trigger = 1;
+        uint32 newState = 2;
+        uint32 oldState = 3;
+    }
+
+    message AstTransitionEvent {
+        bool orchestrator = 1;
+        uint32 newState = 2;
+        uint32 oldState = 3;
+    }
+}
+
+message AudioTestTrait {
+    AudioTestResult speakerResult = 1;
+    AudioTestResult buzzerResult = 2;
+
+    enum AudioTestSource {
+        AUDIO_TEST_SOURCE_UNSPECIFIED = 0;
+        AUDIO_TEST_SOURCE_AUTOMATIC = 1;
+        AUDIO_TEST_SOURCE_MANUAL = 2;
+    }
+
+    enum AudioFaultType {
+        AUDIO_FAULT_TYPE_UNSPECIFIED = 0;
+        AUDIO_FAULT_TYPE_INCONCLUSIVE_OTHER = 1;
+        AUDIO_FAULT_TYPE_INCONCLUSIVE_AMBIENT_NOISE = 2;
+        AUDIO_FAULT_TYPE_INCONCLUSIVE_ASYNC_INTER = 4;
+        AUDIO_FAULT_TYPE_INCONCLUSIVE_DID_NOT_RUN = 8;
+        AUDIO_FAULT_TYPE_INCONCLUSIVE_DROPPED_BUFFER = 16;
+    }
+
+    message AudioTestResult {
+        AudioTestSource source = 1;
+        bool testPassed = 2;
+        repeated AudioFaultType types = 3;
+    }
+
+    message AudioTestStartEvent {
+        AudioTestSource source = 1;
+    }
+
+    message AudioTestEndEvent {
+        AudioTestResult speakerResult = 1;
+        AudioTestResult buzzerResult = 2;
+    }
+}
+
+message ReadyActionTrait {
+    enum ReadyActionState {
+        READY_ACTION_STATE_UNSPECIFIED = 0;
+        READY_ACTION_STATE_IDLE = 1;
+        READY_ACTION_STATE_START_UX = 2;
+        READY_ACTION_STATE_PAIRING_UX = 3;
+    }
+
+    enum ReadyStateChangeReason {
+        READY_STATE_CHANGE_REASON_UNSPECIFIED = 0;
+        READY_STATE_CHANGE_REASON_TIMEOUT = 1;
+        READY_STATE_CHANGE_REASON_BUTTON_PRESS = 2;
+        READY_STATE_CHANGE_REASON_BLE_TRIGGER = 3;
+    }
+
+    message ReadyActionStateChangeEvent {
+        ReadyActionState newReadyActionState = 1;
+        ReadyActionState previousReadyActionState = 2;
+        ReadyStateChangeReason changeReason = 3;
+    }
+}
+
+message TrapActionTrait {
+    enum TrapStatus {
+        TRAP_STATUS_UNSPECIFIED = 0;
+        TRAP_STATUS_NONE = 1;
+        TRAP_STATUS_LAST_GASP_BEGIN = 2;
+        TRAP_STATUS_SAFETY_MCU = 3;
+    }
+
+    message TrapStatusUpdateEvent {
+        TrapStatus newTrapStatus = 1;
+        TrapStatus previousTrapStatus = 2;
+    }
+
+    message SafetyMCUFaultEvent {
+        bool asserted = 1;
+    }
+}
+
+message NightTimePromiseTrait {
+    enum NtpState {
+        NTP_STATE_UNSPECIFIED = 0;
+        NTP_STATE_ALL_CLEAR_NTP_ENABLED = 1;
+        NTP_STATE_ALL_CLEAR_NTP_DISABLED = 2;
+        NTP_STATE_WARNINGS_DISPLAYED = 3;
+        NTP_STATE_WARNINGS_SPOKEN = 4;
+        NTP_STATE_CRITICAL_WARNINGS_SPOKEN = 5;
+        NTP_STATE_DONE = 6;
+    }
+
+    message NightTimePromiseEvent {
+        NtpState state = 1;
+        bool usingRemote = 2;
+        bool criticalWarnings = 3;
+        uint32 warningCount = 4;
+    }
+}
+
+message ProtectDeviceInfoTrait {
+    string deviceExternalColor = 1;
+    CertRegion certificationBody = 2;
+
+    enum CertRegion {
+        CERT_REGION_UNSPECIFIED = 0;
+        CERT_REGION_US = 1;
+        CERT_REGION_EU = 2;
+        CERT_REGION_AU = 3;
+    }
+
+    message AppDailyConnectionStatusEvent {
+        google.protobuf.Timestamp wdmDisconnectTime = 1;
+    }
+}
+
+message SafetySummaryTrait {
+    repeated DeviceStatus criticalDevices = 1;
+    repeated DeviceStatus warningDevices = 2;
+    int32 totalCriticalFailures = 3;
+    int32 totalWarnings = 4;
+    nest.trait.selftest.SelfTestRunnerTrait.TestId testId = 5;
+
+    enum FailureType {
+        FAILURE_TYPE_UNSPECIFIED = 0;
+        FAILURE_TYPE_SMOKE = 1;
+        FAILURE_TYPE_CO = 2;
+        FAILURE_TYPE_TEMP = 4;
+        FAILURE_TYPE_HUM = 8;
+        FAILURE_TYPE_ALS = 16;
+        FAILURE_TYPE_US = 32;
+        FAILURE_TYPE_PIR = 64;
+        FAILURE_TYPE_BUZZER = 128;
+        FAILURE_TYPE_EXPIRED = 256;
+        FAILURE_TYPE_EXPIRING = 512;
+        FAILURE_TYPE_BATT_VERYLOW = 1024;
+        FAILURE_TYPE_BATT_LOW = 2048;
+        FAILURE_TYPE_WIFI = 4096;
+        FAILURE_TYPE_LED = 8192;
+        FAILURE_TYPE_AUDIO = 16384;
+        FAILURE_TYPE_POWEROUT = 32768;
+        FAILURE_TYPE_OFFLINE = 65536;
+    }
+
+    message DeviceStatus {
+        weave.common.ResourceId resourceId = 1;
+        weave.common.ResourceId spokenWhereAnnotation = 2;
+        repeated FailureType failures = 3;
+        repeated FailureType criticalMask = 4;
+        uint32 productId = 5;
+        uint32 vendorId = 6;
+    }
+}
+
+message ActionSchedulerTrait {
+    message ActionSchedulerOpEvent {
+        uint32 opId = 1;
+        uint32 actionId = 2;
+    }
+}
+
+message AudioPlayTrait {
+    message AudioPlayEvent {
+        google.protobuf.UInt32Value sentenceId = 1;
+        google.protobuf.StringValue sentenceString = 2;
+        repeated uint32 sentenceArgIds = 3;
+    }
+}
+
+message LegacyAlarmHistoryTrait {
+    repeated AlarmStatus smokeHistory = 1;
+    repeated AlarmStatus coHistory = 2;
+
+    message AlarmStatus {
+        google.protobuf.Timestamp timestamp = 1;
+        uint32 status = 2;
+        bool synced = 3;
+    }
+}
+
+message LegacySelfTestSettingsTrait {
+    bool astEnabled = 1;
+    bool astNotify = 2;
+    google.protobuf.Duration astRepeatSecs = 3;
+    google.protobuf.Duration astForceSecs = 4;
+    google.protobuf.Duration astStartOffsetUtcSecs = 5;
+    google.protobuf.Duration astEndOffsetUtcSecs = 6;
+
+    message AutomatedSelfTestScheduleChangeEvent {
+        google.protobuf.Duration astStartOffsetUtcSecs = 1;
+        google.protobuf.Duration astEndOffsetUtcSecs = 2;
+    }
+}
+
+message NightTimePromiseSettingsTrait {
+    bool greenLedEnabled = 1;
+    NightTimePromiseBrightness greenLedBrightness = 2;
+
+    enum NightTimePromiseBrightness {
+        NIGHT_TIME_PROMISE_BRIGHTNESS_UNSPECIFIED = 0;
+        NIGHT_TIME_PROMISE_BRIGHTNESS_LOW = 1;
+        NIGHT_TIME_PROMISE_BRIGHTNESS_MEDIUM = 2;
+        NIGHT_TIME_PROMISE_BRIGHTNESS_HIGH = 3;
+    }
+}
+
+message OutOfBoxTrait {
+    message OutOfBoxFinishedEvent {
+        bool success = 1;
+        bool defaultLanguageSelected = 2;
+        bool currentLanguage = 3;
+        bool osmSwapPossible = 4;
+        uint32 repeatCount = 5;
+    }
+}
+
+message LegacyProtectDeviceInfoTrait {
+    string capabilityIdx = 1;
+    bool autoAway = 2;
+    google.protobuf.FloatValue capabilityLevel = 3;
+    bool linePowerCapable = 4;
+    string spSoftwareVersion = 5;
+}
+
+message LegacyProtectDeviceSettingsTrait {
+    google.protobuf.Timestamp replaceByDate = 1;
+}
+
+message SafetyStructureSettingsTrait {
+    string structureHushKey = 1;
+    bool phoneHushEnabled = 2;
+}

--- a/lib/protobuf/nest/trait/selftest.proto
+++ b/lib/protobuf/nest/trait/selftest.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package nest.trait.selftest;
+
+message SelfTestRunnerTrait {
+  enum TestId {
+    TEST_ID_UNSPECIFIED = 0;
+    TEST_ID_1 = 1;
+    TEST_ID_2 = 2;
+    TEST_ID_3 = 3;
+  }
+}

--- a/lib/protobuf/root.proto
+++ b/lib/protobuf/root.proto
@@ -15,6 +15,8 @@ import "weave/trait/security.proto";
 import "weave/trait/power.proto";
 import "nest/trait/security.proto";
 import "nest/trait/detector.proto";
+import "nest/trait/selftest.proto";
+import "nest/trait/product/protect.proto";
 import "nest/messages.proto";
 import "nestlabs/gateway/v1.proto";
 


### PR DESCRIPTION
### Motivation

- Provide an opt-in protobuf-based path for Nest Protect devices so Protects can be mounted from protobuf streams instead of relying on REST `topaz` updates. 
- Parse ambient motion and other protobuf traits to produce occupancy, manual-test, battery and alarm state signals compatible with existing legacy code paths. 
- Preserve wired vs battery distinction and map protobuf health/alarm enums to existing REST-style fields to maintain HomeKit behaviour.

### Description

- Add README documentation for a new option `Protect.Protobuf.Enable` to opt in to experimental protobuf Protect mode. 
- Introduce `PROTECT_PROTOBUF_DEVICE_TYPES` and update `updateData()` to avoid subscribing to REST `topaz` bucket when protobuf Protect mode is enabled. 
- Implement extensive protobuf->legacy translation logic in `protobufToNestLegacy()` including helpers `findEnumValue`, `findBooleanByKeyHints`, `unwrapKnownProtobufPayload`, `decodeBufferWithType`, `objectToBuffer`, `summarizeProtobufKeys`, and related decoding/lookup fallbacks. 
- Mount Protect devices discovered via protobuf when `Protect.Protobuf.Enable` is set and populate legacy `topaz` fields such as `protobuf_occupancy_detected`, `auto_away`, `line_power_present`, `battery_health_state`, `smoke_status`, `co_status`, `component_wifi_test_passed`, and manual-test state. 
- Improve protobuf trait decoding by enhancing `transformTraits()` and `lookupTrait()` to better convert raw buffers into JSON objects and to fall back to `proto.root` lookups. 
- Update `apiResponseToObjectTree()` mapping for Protects to treat battery/health and alarm states appropriately (including special handling for line-powered devices). 
- Update `NestProtectAccessory` to prefer `protobuf_occupancy_detected` for occupancy characteristic, fall back to `auto_away`, and default to not-detected when unknown. 
- Add Protobuf schema files `lib/protobuf/nest/trait/product/protect.proto` and `lib/protobuf/nest/trait/selftest.proto` and import them from `lib/protobuf/root.proto`.

### Testing

- Ran the existing automated test suite with `npm test` and static checks with `npm run lint`, and the test suite completed without failures. 
- Verified protobuf decoding paths by running integration smoke tests against a protobuf observe stream in a development environment and confirmed Protect properties were translated and surfaced to the legacy data model.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf61609a0832c87846682e52ca3c9)